### PR TITLE
Force wheel build to use oldest supported numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ requires = [
     "wheel",
     "toml",
     "setuptools_scm>=4.1.2",
-    "numpy",
+    "numpy==1.13.3; python_version<'3.5'",
+    "oldest-supported-numpy; python_version>='3.5'",
     "cython"
 ]
 


### PR DESCRIPTION
It seems it is best practice to build Cython extensions against the oldest supported version of numpy available per Python version. This helps with forward compatibility with new versions of numpy. 

See: https://pypi.org/project/oldest-supported-numpy/