### PR TITLE
Fix Python 3 bug with integer division

### DIFF
--- a/fastkde/fastKDE.py
+++ b/fastkde/fastKDE.py
@@ -471,7 +471,7 @@ class fastKDE:
     if(self.doSaveTransformedKernel):
       self.kappaSC = kappaSC
 
-    midPointAccessor = tuple([(tp-1)/2 for tp in self.numTPoints])
+    midPointAccessor = tuple([(tp-1)//2 for tp in self.numTPoints])
     #Calculate the transform of the self-consistent density estimate
     self.phiSC[iCalcPhi] = self.ECF[iCalcPhi]*kappaSC[iCalcPhi]
 
@@ -549,7 +549,7 @@ class fastKDE:
 
     if(self.beVerbose):
       normConst = sum(pdf*prod(self.deltaX))
-      midPointAccessor = tuple([(tp-1)/2 for tp in self.numTPoints])
+      midPointAccessor = tuple([(tp-1)//2 for tp in self.numTPoints])
       print("Normalization of pdf = {}. phiSC[0] = {}".format(normConst,self.phiSC[midPointAccessor]))
 
 
@@ -839,7 +839,7 @@ class fastKDE:
       #Transform the PDF to fourier space
       phiTilde_tmp = fft.fftshift(fft.ifftn(fft.ifftshift(ma.filled(pdf,0.0))))
       #Normalize the transform
-      midPointAccessor = tuple([(tp-1)/2 for tp in self.numTPoints])
+      midPointAccessor = tuple([(tp-1)//2 for tp in self.numTPoints])
       phiTilde_tmp /= phiTilde_tmp[midPointAccessor]
 
       #Reapply the filter


### PR DESCRIPTION
The midPointAccessor variable, which is used various places in the code
(mainly but not exclusively in verbose prints), is supposed to be a
tuple of integers to index the array.  But the form used for the
division:

(tp-1)/2

produces a floating point result in Python 3.  And a tuple of floats is
no longer allowed as an index to a numpy array.  The fix is to force
integer division (which is clearly the intent here):

(tp-1)//2

This fix was made 3 places in the code.  It fixes an error in the print
statements when beVerbose=True is specified.