### PR TITLE
Disable py36 wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,7 @@ env:
   CIBW_TEST_EXTRAS: test
   CIBW_TEST_COMMAND: "pytest {project}/tests"
   CIBW_TEST_SKIP: "pp* *universal2:arm64 *musllinux*"
-  CIBW_SKIP: "pp*"
+  CIBW_SKIP: "pp* cp36-*"
 
 jobs:
   build_sdist:


### PR DESCRIPTION
Drops support for Python 3.6 wheels. It seems like setuptools_scm doesn't support 3.6 anymore since it is EOL. I think this is why the versions are getting 0.0.0 for those wheels. I think we can try one more release after this PR is merged and hopefully PyPI will take the upload. I suspect the upload would have failed anyway down the line with those 0.0.0 wheels eventually so that was a nice catch.
