### PR TITLE
cython: Explicitly set language level in .pyx files

### DIFF
--- a/fastkde/floodFillSearch.pyx
+++ b/fastkde/floodFillSearch.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=2
+
 import numpy as np
 cimport numpy as np
 cimport cython

--- a/fastkde/nufft.pyx
+++ b/fastkde/nufft.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=2
+
 import numpy as np
 cimport numpy as np
 cimport cython


### PR DESCRIPTION
cython>=3 changes default language level, so stick with level=2

Closes: https://github.com/LBL-EESA/fastkde/issues/24